### PR TITLE
Truncate results description in public list

### DIFF
--- a/app/views/decidim/results/results/_results.html.erb
+++ b/app/views/decidim/results/results/_results.html.erb
@@ -8,7 +8,7 @@
           <%= link_to result, class: "card__link" do %>
             <h5 class="card__title"><%= translated_attribute result.title %></h5>
           <% end %>
-          <%= sanitize translated_attribute result.description %>
+          <%= sanitize(html_truncate(translated_attribute(result.description), length: 100)) %>
           <%= render partial: "decidim/shared/tags", locals: { resource: result, tags_class_extra: "tags--result" } %>
         </div>
       </article>


### PR DESCRIPTION
#### :tophat: What? Why?
Backports https://github.com/decidim/decidim/pull/2008.

Proposal's description is truncated on the index page so that we don't get a lot of texts. This PR applies this to results, as per #2006. Text is truncated at 100 chars, same as proposals:

![](https://i.imgur.com/gi0Cder.png)

(notice the description is truncated)

